### PR TITLE
added veracode scanning files for Jenkins security pipeline

### DIFF
--- a/.secexclude
+++ b/.secexclude
@@ -1,0 +1,8 @@
+tests/*
+LICENSE
+NOTICE
+README.md
+.gitignore
+.travis.yml
+.github/*
+pull_request_template.md

--- a/.secinclude
+++ b/.secinclude
@@ -1,0 +1,4 @@
+cdis_oauth2client/*
+Pipfile
+Pipfile.lock
+setup.py

--- a/Jenkinsfile.security
+++ b/Jenkinsfile.security
@@ -1,0 +1,6 @@
+#!groovy
+
+@Library('cdis-jenkins-lib@master') _
+
+securityPipeline {
+}


### PR DESCRIPTION
This commit simply adds 3 files that are needed to perform scheduled scans of this repository through the Jenkins security organization pipeline.

### New Features
- Added .secinclude to include all relevant files needed for veracode scan.
- Added .secexclude to explicitly remove any unneeded files.
- Added Jenkinsfile.security for the veracode security organization in Jenkins to scan this repo regularly.